### PR TITLE
Resolve relative server URLs against spec URL

### DIFF
--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -222,10 +222,11 @@ impl App {
                     let name = &self.config.servers[self.server_list.selected].name;
                     if let Some(spec) = self.specs.get(name) {
                         let endpoints = extract_endpoints(spec);
+                        let spec_url = &self.config.servers[self.server_list.selected].url;
                         let server_base = spec
                             .servers
                             .first()
-                            .map(|s| s.url.clone())
+                            .map(|s| resolve_server_base(spec_url, &s.url))
                             .unwrap_or_default();
                         self.endpoint_list =
                             EndpointListState::new(endpoints, name.clone(), server_base);
@@ -497,6 +498,28 @@ impl App {
             }
         });
     }
+}
+
+/// Resolve a server URL from an OpenAPI spec against the URL used to fetch the spec.
+/// If `server_url` is already absolute (starts with a scheme), it is returned as-is.
+/// If it is relative (e.g. `/api/v1`), the scheme and host are taken from `spec_url`.
+fn resolve_server_base(spec_url: &str, server_url: &str) -> String {
+    if server_url.starts_with("http://") || server_url.starts_with("https://") {
+        return server_url.to_string();
+    }
+    // Extract scheme://host from the spec URL and prepend it to the relative server URL.
+    if let Some(scheme_end) = spec_url.find("://") {
+        let after_scheme = &spec_url[scheme_end + 3..];
+        let host_end = after_scheme.find('/').unwrap_or(after_scheme.len());
+        let origin = &spec_url[..scheme_end + 3 + host_end];
+        let path = if server_url.starts_with('/') {
+            server_url.to_string()
+        } else {
+            format!("/{server_url}")
+        };
+        return format!("{origin}{path}");
+    }
+    server_url.to_string()
 }
 
 fn non_empty(s: &str) -> Option<String> {


### PR DESCRIPTION
## Summary
This change improves how server base URLs are resolved when loading OpenAPI specifications. Previously, the code would use the server URL from the spec as-is. Now it properly handles relative server URLs by resolving them against the URL used to fetch the spec itself.

## Key Changes
- Added `resolve_server_base()` function that intelligently handles both absolute and relative server URLs
  - Absolute URLs (starting with `http://` or `https://`) are returned unchanged
  - Relative URLs are resolved by combining the scheme and host from the spec URL with the relative path
  - Handles edge cases like missing leading slashes in relative paths
- Updated the endpoint list initialization to use the new resolution logic instead of directly using the spec's server URL

## Implementation Details
The `resolve_server_base()` function:
- Extracts the origin (scheme + host) from the spec URL by finding the `://` delimiter and the first `/` after it
- Combines the origin with the server URL, ensuring proper path formatting
- Falls back to returning the server URL as-is if the spec URL format is unexpected

https://claude.ai/code/session_01HrGDxinju1SK568LwsFhrh