### PR TITLE
Improve endpoint list filter UX with persistent display and hints

### DIFF
--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -319,6 +319,11 @@ impl App {
             KeyCode::Esc if el.filter_active => {
                 el.filter_active = false;
                 el.filter.clear();
+                el.selected = 0;
+            }
+            KeyCode::Esc if !el.filter.is_empty() => {
+                el.filter.clear();
+                el.selected = 0;
             }
             KeyCode::Esc => self.screen = Screen::ServerList,
             KeyCode::Char('j') | KeyCode::Down if !el.filter_active => el.next(),
@@ -326,12 +331,18 @@ impl App {
             KeyCode::Char('/') if !el.filter_active => {
                 el.filter_active = true;
                 el.filter.clear();
+                el.selected = 0;
             }
             KeyCode::Backspace if el.filter_active => {
                 el.filter.pop();
+                el.selected = 0;
             }
             KeyCode::Char(c) if el.filter_active => {
                 el.filter.push(c);
+                el.selected = 0;
+            }
+            KeyCode::Enter if el.filter_active => {
+                el.filter_active = false;
             }
             KeyCode::Enter => {
                 if let Some(ep) = el.selected_endpoint() {

--- a/crates/tui/src/ui/endpoint_list.rs
+++ b/crates/tui/src/ui/endpoint_list.rs
@@ -18,8 +18,9 @@ pub fn render(f: &mut Frame, app: &App, area: Rect) {
     let inner = outer.inner(area);
     f.render_widget(outer, area);
 
-    // Filter bar at bottom of inner area if active
-    let chunks = if el.filter_active {
+    // Filter bar at bottom of inner area when typing or a filter is applied
+    let show_filter_bar = el.filter_active || !el.filter.is_empty();
+    let chunks = if show_filter_bar {
         Layout::default()
             .direction(Direction::Vertical)
             .constraints([Constraint::Min(0), Constraint::Length(1)])
@@ -73,9 +74,19 @@ pub fn render(f: &mut Frame, app: &App, area: Rect) {
     let list = List::new(items).highlight_style(super::selected_style());
     f.render_stateful_widget(list, list_area, &mut list_state);
 
-    if el.filter_active {
-        let filter_bar =
-            Paragraph::new(format!("/ {}", el.filter)).style(Style::default().fg(Color::Yellow));
+    if show_filter_bar {
+        let (text, style) = if el.filter_active {
+            (
+                format!("/ {}_", el.filter),
+                Style::default().fg(Color::Yellow),
+            )
+        } else {
+            (
+                format!("/ {} (Enter to open, Esc to clear)", el.filter),
+                Style::default().fg(Color::Cyan),
+            )
+        };
+        let filter_bar = Paragraph::new(text).style(style);
         f.render_widget(filter_bar, chunks[1]);
     }
 


### PR DESCRIPTION
## Summary
Enhanced the endpoint list filter functionality to provide better user feedback and a more intuitive filtering experience. The filter bar now persists when a filter is applied (not just when actively typing) and displays contextual hints to guide users.

## Key Changes
- **Persistent filter bar display**: The filter bar now shows whenever `filter_active` is true OR when a filter has been applied, making it clear to users that filtering is in effect
- **Contextual filter bar styling**: 
  - When actively typing (filter_active): Shows cursor indicator (`_`) with yellow styling
  - When filter applied but not typing: Shows helpful hint text ("Enter to open, Esc to clear") with cyan styling
- **Improved filter clearing behavior**: Added `el.selected = 0` reset when clearing filters via Esc key to return to the top of the list
- **Filter activation/deactivation flow**: 
  - Pressing `/` activates filter mode and clears the filter
  - Pressing Enter while typing closes filter mode but keeps the filter applied
  - Pressing Esc while typing clears both the filter and filter mode
  - Pressing Esc with an applied filter (but not typing) clears just the filter
- **Selection reset on filter changes**: Reset selected item to 0 whenever the filter text changes to ensure the list view stays synchronized with filter results

## Implementation Details
The changes maintain backward compatibility while improving the visual feedback loop. The filter bar now serves as both an input indicator and a status display, reducing cognitive load for users navigating filtered endpoint lists.

https://claude.ai/code/session_012mZrP37KG6YdcPrBpqDfzs