### PR TITLE
Rename binary from oapitui to oat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,13 +85,13 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-musl-
 
       - name: Build release binary (static musl)
-        run: cargo build --release --bin oapitui --target x86_64-unknown-linux-musl
+        run: cargo build --release --bin oat --target x86_64-unknown-linux-musl
 
       - name: Rename binary
-        run: cp target/x86_64-unknown-linux-musl/release/oapitui oapitui-linux-x86_64
+        run: cp target/x86_64-unknown-linux-musl/release/oat oat-linux-x86_64
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         with:
-          files: oapitui-linux-x86_64
+          files: oat-linux-x86_64
           generate_release_notes: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,15 +18,15 @@ RUN for dir in crates/config crates/openapi crates/client; do \
     done && \
     mkdir -p crates/tui/src && echo "fn main() {}" > crates/tui/src/main.rs
 
-RUN cargo build --release --bin oapitui --target x86_64-unknown-linux-musl 2>/dev/null; true
+RUN cargo build --release --bin oat --target x86_64-unknown-linux-musl 2>/dev/null; true
 
 COPY crates crates
 RUN touch crates/*/src/*.rs && \
-    cargo build --release --bin oapitui --target x86_64-unknown-linux-musl
+    cargo build --release --bin oat --target x86_64-unknown-linux-musl
 
 # ── Runtime stage (UBI9) ───────────────────────────────────────────────────────
 FROM registry.access.redhat.com/ubi9/ubi-minimal
 
-COPY --from=builder /build/target/x86_64-unknown-linux-musl/release/oapitui /usr/local/bin/oapitui
+COPY --from=builder /build/target/x86_64-unknown-linux-musl/release/oat /usr/local/bin/oat
 
-ENTRYPOINT ["/usr/local/bin/oapitui"]
+ENTRYPOINT ["/usr/local/bin/oat"]

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -189,14 +189,14 @@ impl Config {
 pub fn default_config_path() -> PathBuf {
     dirs::config_dir()
         .unwrap_or_else(|| PathBuf::from("."))
-        .join("oapitui")
+        .join("oat")
         .join("config.toml")
 }
 
 pub fn default_history_path() -> PathBuf {
     dirs::config_dir()
         .unwrap_or_else(|| PathBuf::from("."))
-        .join("oapitui")
+        .join("oat")
         .join("history.json")
 }
 

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [[bin]]
-name = "oapitui"
+name = "oat"
 path = "src/main.rs"
 
 [dependencies]

--- a/crates/tui/src/ui/server_list.rs
+++ b/crates/tui/src/ui/server_list.rs
@@ -10,7 +10,7 @@ use ratatui::{
 
 pub fn render(f: &mut Frame, app: &App, area: Rect) {
     let block = Block::default().borders(Borders::ALL).title(Span::styled(
-        " oapitui — Servers ",
+        " oat — Servers",
         super::title_style(&app.theme),
     ));
 


### PR DESCRIPTION
## Summary
This PR renames the binary and application from `oapitui` to `oat` across the codebase, including build configurations, CI/CD pipelines, and user-facing strings.

## Key Changes
- Updated `crates/tui/Cargo.toml` to change the binary name from `oapitui` to `oat`
- Modified `Dockerfile` to build and reference the `oat` binary instead of `oapitui` in both the builder and runtime stages
- Updated `.github/workflows/ci.yml` to build the `oat` binary and generate release artifacts with the new naming convention
- Updated the UI title in `crates/tui/src/ui/server_list.rs` from "oapitui — Servers" to "oat — Servers"

## Implementation Details
The rename is consistent across all layers:
- Build system (Cargo.toml)
- Container image (Dockerfile)
- CI/CD automation (GitHub Actions)
- Runtime binary paths and entry points
- User-facing UI strings

https://claude.ai/code/session_01TZmtZALAMKqkcyXPwd6y6m